### PR TITLE
Logstash: Convert timestamps to UTC before outputting.

### DIFF
--- a/src/Ocelog.Formatting.Logstash/LogstashJson.cs
+++ b/src/Ocelog.Formatting.Logstash/LogstashJson.cs
@@ -12,7 +12,7 @@ namespace Ocelog.Formatting.Logstash
             var requiredFields = new Dictionary<string, object>()
             {
                 { "@version", 1 },
-                { "@timestamp", logEvent.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture) }
+                { "@timestamp", logEvent.Timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture) }
             };
 
             var allFields = new object[] { requiredFields }

--- a/src/Ocelog.Formatting.Logstash/OldLogstashJson.cs
+++ b/src/Ocelog.Formatting.Logstash/OldLogstashJson.cs
@@ -23,7 +23,7 @@ namespace Ocelog.Formatting.Logstash
 
             var requiredFields = new Dictionary<string, object>()
             {
-                { "@timestamp", logEvent.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture) },
+                { "@timestamp", logEvent.Timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture) },
                 { "@tags", logEvent.Tags },
                 { "@fields", json }
             };


### PR DESCRIPTION
The `should_add_timestamp_in_correct_format` tests failed on my machine.  The reason is that the `Z` in the format string is handled as a literal but does not influence the time zone for the output. Thus the conversion into UTC is needed first.