### PR TITLE
Upgrade reactive extensions to v3.

### DIFF
--- a/package/Ocelog.nuspec
+++ b/package/Ocelog.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Ocelog</id>
-    <version>2.0.6</version>
+    <version>2.1.0</version>
     <authors>Andy Lowry</authors>
     <owners>Andy Lowry</owners>
     <licenseUrl>https://github.com/Ocelog/Ocelog/blob/master/LICENSE</licenseUrl>
@@ -14,9 +14,9 @@
     <copyright>Copyright 2016</copyright>
     <tags>Logging .net Logstash Structured</tags>
     <dependencies>
-      <dependency id="Rx-Core" version="2.2.5" />
-      <dependency id="Rx-Interfaces" version="2.2.5" />
-      <dependency id="Rx-Linq" version="2.2.5" />
+      <dependency id="System.Reactive.Core" version="3.3.1" />
+      <dependency id="System.Reactive.Interfaces" version="3.3.1" />
+      <dependency id="System.Reactive.Linq" version="3.3.1" />
       <dependency id="Newtonsoft.Json" version="6.0.8" />
     </dependencies>
   </metadata>

--- a/package/Ocelog.nuspec
+++ b/package/Ocelog.nuspec
@@ -10,7 +10,7 @@
     <iconUrl>https://raw.githubusercontent.com/Ocelog/Ocelog/master/Ocelog_icon.jpg</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Ocelog is a logging library designed to make Structured logging of objects (not messages) easy</description>
-    <releaseNotes>Fixed merging of non-generic collections. (Bug fix from previous release)</releaseNotes>
+    <releaseNotes>Upgraded to Reactive Extensions v3</releaseNotes>
     <copyright>Copyright 2016</copyright>
     <tags>Logging .net Logstash Structured</tags>
     <dependencies>

--- a/package/Ocelog.nuspec
+++ b/package/Ocelog.nuspec
@@ -14,9 +14,9 @@
     <copyright>Copyright 2016</copyright>
     <tags>Logging .net Logstash Structured</tags>
     <dependencies>
-      <dependency id="System.Reactive.Core" version="3.3.1" />
-      <dependency id="System.Reactive.Interfaces" version="3.3.1" />
-      <dependency id="System.Reactive.Linq" version="3.3.1" />
+      <dependency id="System.Reactive.Core" version="3.1.1" />
+      <dependency id="System.Reactive.Interfaces" version="3.1.1" />
+      <dependency id="System.Reactive.Linq" version="3.1.1" />
       <dependency id="Newtonsoft.Json" version="6.0.8" />
     </dependencies>
   </metadata>

--- a/src/Ocelog.Formatting.Json/Ocelog.Formatting.Json.csproj
+++ b/src/Ocelog.Formatting.Json/Ocelog.Formatting.Json.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Ocelog.Formatting.Json</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Ocelog.Formatting.Logstash/Ocelog.Formatting.Logstash.csproj
+++ b/src/Ocelog.Formatting.Logstash/Ocelog.Formatting.Logstash.csproj
@@ -45,16 +45,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Core.3.1.1\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Linq.3.1.1\lib\net45\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Ocelog.Formatting.Logstash/Ocelog.Formatting.Logstash.csproj
+++ b/src/Ocelog.Formatting.Logstash/Ocelog.Formatting.Logstash.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Ocelog.Formatting.Logstash</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -79,7 +80,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Ocelog.Formatting.Logstash/packages.config
+++ b/src/Ocelog.Formatting.Logstash/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net45" />
 </packages>

--- a/src/Ocelog.Testing/Ocelog.Testing.csproj
+++ b/src/Ocelog.Testing/Ocelog.Testing.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Ocelog.Testing</RootNamespace>
     <AssemblyName>Ocelog.Testing</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,7 +74,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Ocelog.Testing/Ocelog.Testing.csproj
+++ b/src/Ocelog.Testing/Ocelog.Testing.csproj
@@ -44,12 +44,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Core.3.1.1\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Linq.3.1.1\lib\net45\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Ocelog.Testing/packages.config
+++ b/src/Ocelog.Testing/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net45" />
 </packages>

--- a/src/Ocelog.Transport.UDP/Ocelog.Transport.UDP.csproj
+++ b/src/Ocelog.Transport.UDP/Ocelog.Transport.UDP.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Ocelog.Transport.UDP</RootNamespace>
     <AssemblyName>Ocelog.Transport.UDP</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,7 +62,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Ocelog/Ocelog.csproj
+++ b/src/Ocelog/Ocelog.csproj
@@ -45,16 +45,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Core.3.1.1\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Linq.3.1.1\lib\net45\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Ocelog/Ocelog.csproj
+++ b/src/Ocelog/Ocelog.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Ocelog</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -83,7 +84,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Ocelog/packages.config
+++ b/src/Ocelog/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net45" />
 </packages>

--- a/test/Ocelog.Formatting.Logstash.Test/Ocelog.Formatting.Logstash.Test.csproj
+++ b/test/Ocelog.Formatting.Logstash.Test/Ocelog.Formatting.Logstash.Test.csproj
@@ -45,16 +45,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Core.3.1.1\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Linq.3.1.1\lib\net45\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/test/Ocelog.Formatting.Logstash.Test/Ocelog.Formatting.Logstash.Test.csproj
+++ b/test/Ocelog.Formatting.Logstash.Test/Ocelog.Formatting.Logstash.Test.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Ocelog.Formatting.Logstash.Test</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -98,7 +99,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/test/Ocelog.Formatting.Logstash.Test/packages.config
+++ b/test/Ocelog.Formatting.Logstash.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/test/Ocelog.Test/FieldNamesTests.cs
+++ b/test/Ocelog.Test/FieldNamesTests.cs
@@ -1,11 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using System.Reactive.Linq;
 
 namespace Ocelog.Test
 {
+    using System;
+
     public class FieldNamesTests
     {
         [Theory]

--- a/test/Ocelog.Test/Ocelog.Test.csproj
+++ b/test/Ocelog.Test/Ocelog.Test.csproj
@@ -45,16 +45,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Core.3.1.1\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Linq.3.1.1\lib\net45\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/test/Ocelog.Test/Ocelog.Test.csproj
+++ b/test/Ocelog.Test/Ocelog.Test.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Ocelog.Test</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -102,7 +103,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/test/Ocelog.Test/packages.config
+++ b/test/Ocelog.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net45" />
+  <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/test/Ocelog.Testing.Test/Ocelog.Testing.Test.csproj
+++ b/test/Ocelog.Testing.Test/Ocelog.Testing.Test.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Ocelog.Testing.Test</RootNamespace>
     <AssemblyName>Ocelog.Testing.Test</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -84,7 +85,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/test/Ocelog.Transport.UDP.Test/Ocelog.Transport.UDP.Test.csproj
+++ b/test/Ocelog.Transport.UDP.Test/Ocelog.Transport.UDP.Test.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Ocelog.Transport.UDP.Test</RootNamespace>
     <AssemblyName>Ocelog.Transport.UDP.Test</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-46|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -84,7 +85,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
Under new nuget package names.
v3 supports .net core.

Closes #16 