### PR TITLE
Add nuget deploy to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,5 +10,11 @@ build_script:
 test_script:
   - ps: .\runTests.ps1
 artifacts:
-  - path: package\*.nupkg
-
+  - path: package\*.nupkg  
+deploy:
+- provider: NuGet
+  api_key:
+    secure: dGptYUNJUsfQAhDGhSCB11GDWlfpOIkbOkuiyTgIHYpTdZQo5cXHqie7BA7fKIMW
+  skip_symbols: false
+  on:
+    branch: master


### PR DESCRIPTION
As my previous PR introduced an appveyor.yml file, now the nuget deployment stuff needs replicating - the deployment section here looks like it should work, though the only way to test it is to merge into master.

The section has been copied and pasted from the 'Export YAML' section of the Appveyor UI - it will be using the same nupkg artifacts as before