### PR TITLE
downgraded Dataflow to 4.7

### DIFF
--- a/package/Ocelog.nuspec
+++ b/package/Ocelog.nuspec
@@ -17,7 +17,7 @@
 		  <dependency id="System.Reactive.Core" version="3.1.1" />
 		  <dependency id="System.Reactive.Interfaces" version="3.1.1" />
 		  <dependency id="System.Reactive.Linq" version="3.1.1" />
-      <dependency id="System.Threading.Tasks.Dataflow" version="4.9.0" />
+      <dependency id="System.Threading.Tasks.Dataflow" version="4.7.0" />
       <dependency id="System.ValueTuple" version="4.5.0" />
 		  <dependency id="Newtonsoft.Json" version="6.0.8" />
 		</group>
@@ -25,7 +25,7 @@
 		  <dependency id="System.Reactive.Core" version="3.1.1" />
 		  <dependency id="System.Reactive.Interfaces" version="3.1.1" />
 		  <dependency id="System.Reactive.Linq" version="3.1.1" />
-      <dependency id="System.Threading.Tasks.Dataflow" version="4.9.0" />
+      <dependency id="System.Threading.Tasks.Dataflow" version="4.7.0" />
       <dependency id="System.ValueTuple" version="4.5.0" />
 		  <dependency id="Newtonsoft.Json" version="6.0.8" />
 		</group>

--- a/src/Ocelog.Transport/Ocelog.Transport.csproj
+++ b/src/Ocelog.Transport/Ocelog.Transport.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Dataflow 4.9 was expecting NetStandard.Library to be in place, which only seems to work given latest build tools

Downgrading to 4.7 will result in loads of bitty small dependencies downstream, but should (fingers crossed!) work without the latest sdks